### PR TITLE
feat: google OAuth 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
     // CORS/WebFlux (프로젝트에 이미 사용 중)
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
@@ -35,6 +37,10 @@ dependencies {
 
     // JSON 처리
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,10 @@ dependencies {
     // JSON 처리
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+   // Lombok
     compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.38'
 
     // CORS/WebFlux (프로젝트에 이미 사용 중)
     implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/src/main/java/com/capstone/domain/user/entity/User.java
+++ b/src/main/java/com/capstone/domain/user/entity/User.java
@@ -5,11 +5,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.sql.Timestamp;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Getter
@@ -30,4 +33,9 @@ public class User {
   @Setter
   private String refreshToken;
 
+  @CreationTimestamp
+  private Timestamp createdAt;
+
+  @UpdateTimestamp
+  private Timestamp updatedAt;
 }

--- a/src/main/java/com/capstone/domain/user/entity/User.java
+++ b/src/main/java/com/capstone/domain/user/entity/User.java
@@ -1,0 +1,33 @@
+package com.capstone.domain.user.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "users")
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String email;
+  private String name;
+  private String profileImage;
+
+  @Setter
+  private String refreshToken;
+
+}

--- a/src/main/java/com/capstone/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/capstone/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.capstone.domain.user.repository;
+
+import com.capstone.domain.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/capstone/global/config/AppConfig.java
+++ b/src/main/java/com/capstone/global/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.capstone.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/src/main/java/com/capstone/global/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/global/config/SecurityConfig.java
@@ -15,32 +15,34 @@ import java.util.Arrays;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-            .csrf(csrf -> csrf.disable())
-            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-            .authorizeHttpRequests(authz -> authz
-                .requestMatchers("/health", "/actuator/**", "/socket.io/**").permitAll()
-                .requestMatchers("/api/sessions/**", "/api/users/**", "/api/chat/**", "/api/ideas/**").permitAll()
-                .requestMatchers("/api/v1/workspaces/**").permitAll()
-                .anyRequest().authenticated()
-            );
-        
-        return http.build();
-    }
-    
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(Arrays.asList("*"));
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("*"));
-        configuration.setAllowCredentials(true);
-        configuration.setMaxAge(3600L);
-        
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
-    }
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(csrf -> csrf.disable())
+        .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+        .authorizeHttpRequests(authz -> authz
+            .requestMatchers("/health", "/actuator/**", "/socket.io/**").permitAll()
+            .requestMatchers("/api/sessions/**", "/api/users/**", "/api/chat/**", "/api/ideas/**")
+            .permitAll()
+            .requestMatchers("/api/v1/workspaces/**").permitAll()
+            .requestMatchers("/api/v1/auth/google/**").permitAll()
+            .anyRequest().authenticated()
+        );
+
+    return http.build();
+  }
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedOriginPatterns(Arrays.asList("*"));
+    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    configuration.setAllowedHeaders(Arrays.asList("*"));
+    configuration.setAllowCredentials(true);
+    configuration.setMaxAge(3600L);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
+  }
 }

--- a/src/main/java/com/capstone/global/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/global/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
             .requestMatchers("/api/sessions/**", "/api/users/**", "/api/chat/**", "/api/ideas/**")
             .permitAll()
             .requestMatchers("/api/v1/workspaces/**").permitAll()
-            .requestMatchers("/api/v1/auth/google/**").permitAll()
+            .requestMatchers("/api/v1/auth-google/**").permitAll()
             .anyRequest().authenticated()
         );
 

--- a/src/main/java/com/capstone/global/oauth/JwtProvider.java
+++ b/src/main/java/com/capstone/global/oauth/JwtProvider.java
@@ -1,0 +1,44 @@
+package com.capstone.global.oauth;
+
+import io.jsonwebtoken.Jwts;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+
+  private final SecretKey secretKey;
+  private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60 * 60;
+  private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 7;
+
+  public JwtProvider(@Value("${spring.jwt.secret}") String secret) {
+    this.secretKey = new SecretKeySpec(
+        secret.getBytes(StandardCharsets.UTF_8),
+        Jwts.SIG.HS256.key().build().getAlgorithm()
+    );
+  }
+
+  public String createAccessToken(Long userId, String email) {
+    return Jwts.builder()
+        .subject(email)
+        .claim("user_id", userId)
+        .issuedAt(new Date())
+        .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME))
+        .signWith(secretKey)
+        .compact();
+  }
+
+  public String createRefreshToken(Long userId, String email) {
+    return Jwts.builder()
+        .subject(email)
+        .claim("user_id", userId)
+        .issuedAt(new Date())
+        .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRE_TIME))
+        .signWith(secretKey)
+        .compact();
+  }
+}

--- a/src/main/java/com/capstone/global/oauth/TokenDto.java
+++ b/src/main/java/com/capstone/global/oauth/TokenDto.java
@@ -1,0 +1,12 @@
+package com.capstone.global.oauth;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenDto {
+
+  private String accessToken;
+  private String refreshToken;
+}

--- a/src/main/java/com/capstone/global/oauth/controller/GoogleController.java
+++ b/src/main/java/com/capstone/global/oauth/controller/GoogleController.java
@@ -1,0 +1,29 @@
+package com.capstone.global.oauth.controller;
+
+import com.capstone.global.oauth.TokenDto;
+import com.capstone.global.oauth.service.GoogleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth-google")
+@RequiredArgsConstructor
+public class GoogleController {
+
+  @Value("${oauth2.google.login-uri}")
+  private String loginUri;
+
+  private final GoogleService googleService;
+
+  @PostMapping
+  public ResponseEntity<TokenDto> loginOrJoin(@RequestParam String code) {
+    return ResponseEntity.ok(googleService.loginOrJoin(code));
+  }
+
+  @GetMapping("/login-uri")
+  public ResponseEntity<String> getLoginUri() {
+    return ResponseEntity.ok(loginUri);
+  }
+}

--- a/src/main/java/com/capstone/global/oauth/service/GoogleService.java
+++ b/src/main/java/com/capstone/global/oauth/service/GoogleService.java
@@ -20,7 +20,7 @@ public class GoogleService {
 
   private final UserRepository userRepository;
   private final JwtProvider jwtProvider;
-  private final RestTemplate restTemplate = new RestTemplate();
+  private  final RestTemplate restTemplate;
 
   @Value("${oauth2.google.client-id}")
   private String clientId;

--- a/src/main/java/com/capstone/global/oauth/service/GoogleService.java
+++ b/src/main/java/com/capstone/global/oauth/service/GoogleService.java
@@ -1,0 +1,95 @@
+package com.capstone.global.oauth.service;
+
+import com.capstone.domain.user.entity.User;
+import com.capstone.domain.user.repository.UserRepository;
+import com.capstone.global.oauth.JwtProvider;
+import com.capstone.global.oauth.TokenDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleService {
+
+  private final UserRepository userRepository;
+  private final JwtProvider jwtProvider;
+  private final RestTemplate restTemplate = new RestTemplate();
+
+  @Value("${oauth2.google.client-id}")
+  private String clientId;
+
+  @Value("${oauth2.google.client-secret}")
+  private String clientSecret;
+
+  @Value("${oauth2.google.redirect-uri}")
+  private String redirectUri;
+
+  @Value("${oauth2.google.token-uri}")
+  private String tokenUri;
+
+  @Value("${oauth2.google.resource-uri}")
+  private String resourceUri;
+
+  public TokenDto loginOrJoin(String code) {
+    String accessToken = getAccessToken(code);
+
+    JsonNode userInfo = getUserResource(accessToken);
+
+    String email = userInfo.get("email").asText();
+    String name = userInfo.get("name").asText();
+    String picture = userInfo.get("picture").asText();
+
+    User user = userRepository.findByEmail(email.trim())
+        .orElseGet(() -> userRepository.save(
+            User.builder()
+                .email(email)
+                .name(name)
+                .profileImage(picture)
+                .build()
+        ));
+
+    String jwtAccessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail());
+    String jwtRefreshToken = jwtProvider.createRefreshToken(user.getId(), user.getEmail());
+
+    user.setRefreshToken(jwtRefreshToken);
+    userRepository.save(user);
+
+    return TokenDto.builder()
+        .accessToken(jwtAccessToken)
+        .refreshToken(jwtRefreshToken)
+        .build();
+  }
+
+  private String getAccessToken(String code) {
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("code", code);
+    params.add("client_id", clientId);
+    params.add("client_secret", clientSecret);
+    params.add("redirect_uri", redirectUri);
+    params.add("grant_type", "authorization_code");
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(params, headers);
+
+    JsonNode response = restTemplate.exchange(tokenUri, HttpMethod.POST, entity, JsonNode.class)
+        .getBody();
+    return Objects.requireNonNull(response).get("access_token").asText();
+  }
+
+  private JsonNode getUserResource(String accessToken) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", "Bearer " + accessToken);
+    HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+    return restTemplate.exchange(resourceUri, HttpMethod.GET, entity, JsonNode.class).getBody();
+  }
+}

--- a/src/test/java/com/capstone/controller/GoogleControllerTest.java
+++ b/src/test/java/com/capstone/controller/GoogleControllerTest.java
@@ -1,0 +1,67 @@
+package com.capstone.controller;
+
+import com.capstone.global.oauth.TokenDto;
+import com.capstone.global.oauth.controller.GoogleController;
+import com.capstone.global.oauth.service.GoogleService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(GoogleController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class GoogleControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private GoogleService googleService;
+
+  @Test
+  @DisplayName("로그인 & 회원가입 성공 테스트")
+  void successLoginOrJoin() throws Exception {
+
+    TokenDto tokenDto = TokenDto.builder()
+        .accessToken("access")
+        .refreshToken("refresh")
+        .build();
+
+    given(googleService.loginOrJoin("Wrong Code")).willReturn(tokenDto);
+
+    mockMvc.perform(post("/api/v1/auth-google")
+            .param("code", "Wrong Code")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accessToken").value("access"))
+        .andExpect(jsonPath("$.refreshToken").value("refresh"));
+  }
+
+
+  @Test
+  @DisplayName("로그인 & 회원가입 실패 테스트")
+  void failLoginOrJoin() {
+    when(googleService.loginOrJoin(anyString()))
+        .thenThrow(new RuntimeException("구글 인증 실패"));
+
+    Throwable exception = assertThrows(Exception.class,
+        () -> mockMvc.perform(post("/api/v1/auth-google")
+                .param("code", "Wrong Code"))
+            .andReturn());
+
+    assertEquals("구글 인증 실패", exception.getCause().getMessage());
+
+  }
+}

--- a/src/test/java/com/capstone/service/GoogleServiceTest.java
+++ b/src/test/java/com/capstone/service/GoogleServiceTest.java
@@ -1,0 +1,108 @@
+package com.capstone.service;
+
+import com.capstone.domain.user.entity.User;
+import com.capstone.domain.user.repository.UserRepository;
+import com.capstone.global.oauth.JwtProvider;
+import com.capstone.global.oauth.TokenDto;
+import com.capstone.global.oauth.service.GoogleService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.*;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleServiceTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private JwtProvider jwtProvider;
+
+  @Mock
+  private RestTemplate restTemplate;
+
+  @InjectMocks
+  private GoogleService googleService;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(googleService, "clientId", "capstone-id");
+    ReflectionTestUtils.setField(googleService, "clientSecret", "capstone-secret");
+    ReflectionTestUtils.setField(googleService, "redirectUri", "http://localhost/capstone");
+    ReflectionTestUtils.setField(googleService, "tokenUri", "http://capstone-token-uri");
+    ReflectionTestUtils.setField(googleService, "resourceUri", "http://capstone-resource-uri");
+
+    when(jwtProvider.createAccessToken(anyLong(), anyString())).thenReturn("access");
+    when(jwtProvider.createRefreshToken(anyLong(), anyString())).thenReturn("refresh");
+
+    lenient().when(jwtProvider.createAccessToken(anyLong(), anyString())).thenReturn("access");
+    lenient().when(jwtProvider.createRefreshToken(anyLong(), anyString()))
+        .thenReturn("refresh");
+  }
+
+  @Test
+  @DisplayName("로그인 & 회원가입 성공 테스트")
+  void successLoginOrJoin() throws Exception {
+    User existingUser = User.builder()
+        .id(1L)
+        .email("capstone@test.com")
+        .name("cap")
+        .profileImage("profile.png")
+        .build();
+
+    JsonNode tokenResponse = objectMapper.readTree("{\"access_token\":\"mock-access-token\"}");
+    when(restTemplate.exchange(eq("http://capstone-token-uri"), eq(HttpMethod.POST),
+        any(HttpEntity.class), eq(JsonNode.class)))
+        .thenReturn(new ResponseEntity<>(tokenResponse, HttpStatus.OK));
+
+    JsonNode userInfoResponse = objectMapper.readTree(
+        "{\"email\":\"capstone@test.com\",\"name\":\"cap\",\"picture\":\"profile.png\"}");
+    when(restTemplate.exchange(eq("http://capstone-resource-uri"), eq(HttpMethod.GET),
+        any(HttpEntity.class), eq(JsonNode.class)))
+        .thenReturn(new ResponseEntity<>(userInfoResponse, HttpStatus.OK));
+
+    when(userRepository.findByEmail("capstone@test.com")).thenReturn(Optional.of(existingUser));
+    when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    TokenDto tokenDto = googleService.loginOrJoin("auth-code");
+
+    assertNotNull(tokenDto);
+    assertEquals("access", tokenDto.getAccessToken());
+    assertEquals("refresh", tokenDto.getRefreshToken());
+
+    verify(userRepository, times(1)).findByEmail("capstone@test.com");
+    verify(userRepository, times(1)).save(existingUser);
+  }
+
+  @Test
+  @DisplayName("로그인 & 회원가입 실패 테스트")
+  void failLoginOrJoin() {
+    when(restTemplate.exchange(
+        anyString(),
+        eq(HttpMethod.POST),
+        any(HttpEntity.class),
+        eq(JsonNode.class)
+    )).thenThrow(new RuntimeException("capstone-token-uri 실패"));
+
+    RuntimeException exception = assertThrows(RuntimeException.class,
+        () -> googleService.loginOrJoin("code"));
+    assertEquals("capstone-token-uri 실패", exception.getMessage());
+  }
+}


### PR DESCRIPTION
### 변경사항
1. GoogleController
- loginOrJoin() - Google 로그인/회원가입
  - 클라이언트에서 전달된 `code`를 기반으로 GoogleService의 `loginOrJoin()` 호출
  - 반환된 JWT `Access Token`과 `Refresh Token`을 ResponseEntity로 반환
- getLoginUri() - Google 로그인 페이지 URL 제공
  - Google 로그인 버튼 클릭 시 프론트가 이동할 수 있는 URL 반환
  - application.yml에서 설정한 `login-uri` 값을 사용
2. GoogleService
- loginOrJoin() - Google OAuth 인증 및 JWT 발급
  - Google API로 Access Token 요청
  - `Access Token`으로 사용자 정보(email, name, picture) 조회
  - DB에서 이메일 기준으로 사용자 조회
     - 기존 사용자 없으면 새 User 엔티티 생성 후 저장
  - JWT `Access Token` 및 `Refresh Token` 생성
  - Refresh Token을 User 엔티티에 저장 후 DB 갱신
  - 최종적으로 TokenDto로 Access Token과 Refresh Token 반환
- getAccessToken() - Google 토큰 발급
  - `code, clientId, clientSecret, redirectUri, grant_type`을 포함하여 POST 요청
  - Google OAuth 토큰 API 호출 후 Access Token 추출
- getUserResource() - Google 사용자 정보 조회
  - Access Token을 `Authorization 헤더`에 포함하여 GET 요청
  - Google 사용자 정보 API에서 `email, name, picture` 추출
3. JwtProvider
- Access Token과 Refresh Token 생성
- 토큰에 이메일과 userId 클레임 포함
- Access Token은 1시간, Refresh Token은 7일 만료
4. TokenDto
- Access Token과 Refresh Token 포함
5. AppConfig
- RestTemplate Bean 등록
- GoogleService에서 RestTemplate `직접 생성하지 않고 주입받아 사용`
6. User 엔티티
- email, name, profileImage
- refreshToken (JWT Refresh Token 저장)
- createdAt, updatedAt (생성/수정 시간 자동 관리)
- JPA 엔티티로 DB 테이블 `users`와 매핑
7. UserRepository
- 이메일 기준 사용자 조회
8. Spring Security 설정
- `.requestMatchers("/api/v1/auth-google/**").permitAll()` 추가
- `/api/v1/auth-google/**` 경로로 들어오는 요청은 인증 없이 접근 가능

### 테스트

- [x] 테스트 코드
- [x] API 테스트 