### PR TITLE
feat: Google OAuth2 iOS 플랫폼 구현

### DIFF
--- a/src/main/java/com/capstone/global/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.capstone.global.config;
 
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -27,7 +28,7 @@ public class SecurityConfig {
     http
         .csrf(csrf -> csrf.disable())
         .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-        .authorizeHttpRequests(authz -> authz
+        .authorizeHttpRequests(auth -> auth
 
             // Health check & Actuator
             .requestMatchers("/v1/health", "/actuator/**").permitAll()
@@ -91,8 +92,11 @@ public class SecurityConfig {
     CorsConfiguration configuration = new CorsConfiguration();
     // 구성 파일 기반 허용 Origin 적용
     configuration.setAllowedOriginPatterns(appProperties.getAllowedOrigins());
-    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
-    configuration.setAllowedHeaders(Arrays.asList("*"));
+    configuration.setAllowedOriginPatterns(
+        List.of("https://*.ngrok-free.dev", "http://localhost:3000"));
+    configuration.setAllowedMethods(
+        Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+    configuration.setAllowedMethods(List.of("*"));
     configuration.setAllowCredentials(true);
     configuration.setMaxAge(3600L);
 

--- a/src/main/java/com/capstone/global/oauth/TokenDto.java
+++ b/src/main/java/com/capstone/global/oauth/TokenDto.java
@@ -9,4 +9,6 @@ public class TokenDto {
 
   private String accessToken;
   private String refreshToken;
+  private String name;
+  private String email;
 }

--- a/src/main/java/com/capstone/global/oauth/controller/GoogleController.java
+++ b/src/main/java/com/capstone/global/oauth/controller/GoogleController.java
@@ -3,13 +3,13 @@ package com.capstone.global.oauth.controller;
 import com.capstone.global.config.AppProperties;
 import com.capstone.global.oauth.TokenDto;
 import com.capstone.global.oauth.service.GoogleService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @RestController
@@ -20,16 +20,20 @@ public class GoogleController {
   private final GoogleService googleService;
   private final AppProperties appProperties;
 
-  @Value("${oauth2.google.client-id}")
+  @Value("${oauth2.google.web.client-id}")
   private String clientId;
 
-  @Value("${oauth2.google.login-uri}")
+  @Value("${oauth2.google.ios.client-id}")
+  private String iosClientId;
+
+  @Value("${oauth2.google.login-uri:https://accounts.google.com/o/oauth2/v2/auth}")
   private String loginUriBase;
 
   @PostMapping
   public ResponseEntity<TokenDto> loginOrJoin(
       @RequestParam String code,
       @RequestParam(value = "redirect_uri", required = false) String redirectUriParam,
+      @RequestParam(value = "platform", required = false) String platform,
       @RequestHeader(value = "Origin", required = false) String origin) {
     log.info("OAuth 콜백 요청 수신 - code: {}, origin: {}, redirect_uri: {}",
         code != null ? code.substring(0, Math.min(10, code.length())) + "..." : "null",
@@ -45,7 +49,8 @@ public class GoogleController {
         dynamicRedirectUri = resolveRedirectUri(origin);
         log.info("OAuth 로그인 처리 - Origin 헤더 기반: {}, Redirect URI: {}", origin, dynamicRedirectUri);
       }
-      TokenDto tokenDto = googleService.loginOrJoin(code, dynamicRedirectUri);
+      boolean isIos = "ios".equalsIgnoreCase(platform);
+      TokenDto tokenDto = googleService.loginOrJoin(code, dynamicRedirectUri, isIos);
       log.info("OAuth 로그인 성공 - 리다이렉트: {}", dynamicRedirectUri);
       return ResponseEntity.ok(tokenDto);
     } catch (Exception e) {
@@ -56,32 +61,43 @@ public class GoogleController {
 
   @GetMapping("/login-uri")
   public ResponseEntity<String> getLoginUri(
-      @RequestHeader(value = "Origin", required = false) String origin,
-      @RequestParam(value = "redirect_uri", required = false) String redirectUriParam) {
-    
-    // redirect_uri 파라미터가 있으면 우선 사용, 없으면 Origin 헤더 기반으로 결정
-    String dynamicRedirectUri;
-    if (redirectUriParam != null && !redirectUriParam.trim().isEmpty()) {
-      dynamicRedirectUri = redirectUriParam;
-      log.info("OAuth 로그인 URI 생성 - redirect_uri 파라미터 사용: {}", dynamicRedirectUri);
+      @RequestParam(value = "redirect_uri", required = false) String redirectUriParam,
+      @RequestParam(value = "platform", required = false) String platform,
+      HttpServletResponse response) {
+    boolean isIos = "ios".equalsIgnoreCase(platform);
+
+    if (redirectUriParam == null || redirectUriParam.trim().isEmpty()) {
+      throw new IllegalArgumentException("redirect_uri는 필수입니다.");
+    }
+    response.setHeader("ngrok-skip-browser-warning", "any-value");
+    String dynamicRedirectUri = redirectUriParam;
+
+    // platform & redirect_uri 검증
+    if (isIos) {
+      if (!dynamicRedirectUri.startsWith("com.googleusercontent.apps")) {
+        throw new IllegalArgumentException("iOS redirect_uri 형식이 아닙니다.");
+      }
     } else {
-      dynamicRedirectUri = resolveRedirectUri(origin);
-      log.info("OAuth 로그인 URI 생성 - Origin 헤더 기반: {}, Redirect URI: {}", origin, dynamicRedirectUri);
+      if (!dynamicRedirectUri.startsWith("http")) {
+        throw new IllegalArgumentException("웹 redirect_uri 형식이 아닙니다.");
+      }
     }
 
-    // 동적으로 Google OAuth 로그인 URL 생성
+    log.info("OAuth 로그인 URI 생성 - platform: {}, redirect_uri: {}", platform, dynamicRedirectUri);
+
+    String selectedClientId = isIos ? iosClientId : clientId;
+
     String scope = "openid email profile";
-    String responseType = "code";
-    
-    String loginUri = String.format(
-      "%s?client_id=%s&redirect_uri=%s&response_type=%s&scope=%s",
-      loginUriBase,
-      URLEncoder.encode(clientId, StandardCharsets.UTF_8),
-      URLEncoder.encode(dynamicRedirectUri, StandardCharsets.UTF_8),
-      responseType,
-      URLEncoder.encode(scope, StandardCharsets.UTF_8)
-    );
-    
+
+    String loginUri = UriComponentsBuilder.fromHttpUrl(loginUriBase)
+        .queryParam("client_id", selectedClientId)
+        .queryParam("redirect_uri", dynamicRedirectUri)
+        .queryParam("response_type", "code")
+        .queryParam("scope", scope)
+        .build()
+        .toUriString();
+
+    log.info("생성된 최종 Login URI: {}", loginUri);
     return ResponseEntity.ok(loginUri);
   }
 

--- a/src/main/java/com/capstone/global/oauth/service/GoogleService.java
+++ b/src/main/java/com/capstone/global/oauth/service/GoogleService.java
@@ -27,11 +27,17 @@ public class GoogleService {
   private final JwtProvider jwtProvider;
   private final RestTemplate restTemplate;
 
-  @Value("${oauth2.google.client-id}")
+  @Value("${oauth2.google.web.client-id}")
   private String clientId;
 
-  @Value("${oauth2.google.client-secret}")
+  @Value("${oauth2.google.web.client-secret}")
   private String clientSecret;
+
+  @Value("${oauth2.google.ios.client-id}")
+  private String iosClientId;
+
+  @Value("${oauth2.google.ios.client-secret:}")
+  private String iosClientSecret;
 
   @Value("${oauth2.google.token-uri}")
   private String tokenUri;
@@ -40,32 +46,32 @@ public class GoogleService {
   private String resourceUri;
 
   @Transactional
-  public TokenDto loginOrJoin(String code, String redirectUri) {
-    log.info("OAuth 로그인 시작 - code: {}, redirectUri: {}", 
+  public TokenDto loginOrJoin(String code, String redirectUri, boolean isIos) {
+    log.info("OAuth 로그인 시작 - code: {}, redirectUri: {}",
         code != null ? code.substring(0, Math.min(10, code.length())) + "..." : "null",
         redirectUri);
-    
+
     try {
-    String accessToken = getAccessToken(code, redirectUri);
+      String accessToken = getAccessToken(code, redirectUri, isIos);
       log.info("Access token 획득 성공");
-      
-    JsonNode userInfo = getUserInfo(accessToken);
+
+      JsonNode userInfo = getUserInfo(accessToken);
       log.info("사용자 정보 획득 성공");
 
-    String email = userInfo.get("email").asText();
-    String name = userInfo.get("name").asText();
+      String email = userInfo.path("email").asText();
+      String name = userInfo.path("name").asText();
       String picture = userInfo.get("picture") != null ? userInfo.get("picture").asText() : null;
-      
+
       log.info("사용자 정보 - email: {}, name: {}", email, name);
 
-    User user = userRepository.findByEmail(email.trim())
+      User user = userRepository.findByEmail(email.trim())
           .orElseGet(() -> {
             log.info("새 사용자 생성 시도 - email: {}, name: {}", email, name);
             try {
               User newUser = User.builder()
                   .email(email.trim())
-                .name(name)
-                .profileImage(picture)
+                  .name(name)
+                  .profileImage(picture)
                   .build();
               User saved = userRepository.save(newUser);
               log.info("사용자 저장 완료 - id: {}, email: {}", saved.getId(), saved.getEmail());
@@ -83,28 +89,34 @@ public class GoogleService {
 
       log.info("기존/신규 사용자 확인 - id: {}, email: {}", user.getId(), user.getEmail());
 
-    String jwtAccessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail());
-    String jwtRefreshToken = jwtProvider.createRefreshToken(user.getId(), user.getEmail());
+      String jwtAccessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail());
+      String jwtRefreshToken = jwtProvider.createRefreshToken(user.getId(), user.getEmail());
 
-    user.setRefreshToken(jwtRefreshToken);
+      user.setRefreshToken(jwtRefreshToken);
       User updatedUser = userRepository.save(user);
-      log.info("Refresh token 저장 완료 - id: {}, email: {}", updatedUser.getId(), updatedUser.getEmail());
+      log.info("Refresh token 저장 완료 - id: {}, email: {}", updatedUser.getId(),
+          updatedUser.getEmail());
 
-    return TokenDto.builder()
-        .accessToken(jwtAccessToken)
-        .refreshToken(jwtRefreshToken)
-        .build();
+      return TokenDto.builder()
+          .accessToken(jwtAccessToken)
+          .refreshToken(jwtRefreshToken)
+          .name(user.getName())
+          .email(user.getEmail())
+          .build();
     } catch (Exception e) {
       log.error("OAuth 로그인 처리 중 오류 발생", e);
       throw e;
     }
   }
 
-  private String getAccessToken(String code, String dynamicRedirectUri) {
+  private String getAccessToken(String code, String dynamicRedirectUri, boolean isIos) {
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("code", code);
-    params.add("client_id", clientId);
-    params.add("client_secret", clientSecret);
+    String selectedClientId = isIos ? iosClientId : clientId;
+    String selectedClientSecret = isIos ? iosClientSecret : clientSecret;
+
+    params.add("client_id", selectedClientId);
+    params.add("client_secret", selectedClientSecret);
     params.add("redirect_uri", dynamicRedirectUri);
     params.add("grant_type", "authorization_code");
 


### PR DESCRIPTION
### 변경사항

1. Google OAuth 로직 플랫폼 확장
- 멀티 클라이언트 대응: Web과 iOS 환경별로 상이한 클라이언트 ID 및 Secret을 주입받아 동적으로 선택하는 로직 구현
- 플랫폼 분기 처리: `platform 파라미터(web, ios)` 에 따라 인증 흐름을 제어하도록 `Controller` 및 `Service` 확장
2. GoogleController 개선
- GET  `/v1/auth-google/login-uri` :
  - platform 및 redirect_uri 유효성 검사 로직 추가
  - UriComponentsBuilder를 도입하여 안정적인 URI 생성 및 특수문자 인코딩 처리
  - iOS 요청 시  `com.googleusercontent.apps`  형식의 리디렉션 스키마 검증
- POST  `/v1/auth-google` :
  - 콜백 시에도 플랫폼별 Client 정보를 매칭하여 구글 토큰 서버와의 통신 정합성 확보
  - ngrok 테스트 환경 대응을 위한 ngrok-skip-browser-warning 헤더 설정 추가
3. GoogleService 및 DTO 고도화
- 사용자 정보 획득: JSON 파싱 시  `path()`  메서드를 사용하여 `Null` 안정성 확보
- TokenDto 확장: 인증 성공 시 토큰 `(accessToken, refreshToken)`  외에 사용자 정보 `(name, email)` 를 추가로 반환
4. SecurityConfig 보안 및 CORS 설정 업데이트
-  CORS 설정: 개발 및 외부망 테스트를 위해  `*.ngrok-free.dev`  및 ` localhost`  도메인 허용 패턴 추가
- `AllowedMethods` 를  `List.of("*")` 로 설정하여 모든`  HTTP 메서드 `(PATCH, OPTIONS 포함)에 대응
- `AllowedHeaders를` *로 설정하여 커스텀 헤더 통신 허용
- 보안 필터 체인: `/v1/auth-google/**`  경로에 대해  `permitAll()` 설정 유지 확인 및 코드 정돈
-  `.authorizeHttpRequests(authz -> authz`를  `.authorizeHttpRequests(auth -> auth`로 수정
-------------------------------------
1. iOS 환경 시뮬레이션 테스트
- 현재 네이티브 앱 빌드 전 단계이므로, 브라우저를 통해 iOS 인증 플로우를 선제적으로 검증했습니다.
- 테스트 URL:  `.../login-uri?platform=ios&redirect_uri=com.googleusercontent.apps.{ClientID}:/oauth2redirect/google` 
   - 서버가 iOS용 클라이언트 ID를 구글로 정상 전달하여 '승인 오류' 없이 로그인 페이지 진입 확인
   - 로그인 완료 후 구글이 iOS 전용 스키마(com.google...)로 리디렉션을 시도하는 것 확인
2. Web 환경 통합 테스트
- 테스트 URL:  `.../login-uri?platform=web&redirect_uri={ngrok_address}/api/v1/auth-google` 
- 구글 인증 완료 후 서버 콜백(POST) 단계에서 인증 코드를 정상적으로 수신
- 수신된 코드로 구글 토큰 교환 및 사용자 정보 획득 확인
- DB 연동: 신규 사용자 자동 가입 및 기존 사용자 로그인 처리 확인 (DBeaver 검증 완료)
 

### 테스트

- [ ] 테스트 코드

- [x] API 테스트 