### PR TITLE
fix: oauth2 ios config 누락으로 인한 bean 생성 오류 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,16 +41,21 @@ openai:
 # OAuth2 (Google) 로컬 기본값
 oauth2:
   google:
-    client-id: ${GOOGLE_CLIENT_ID:your-google-client-id}
-    client-secret: ${GOOGLE_CLIENT_SECRET:your-google-client-secret}
+    web:
+      client-id: ${GOOGLE_CLIENT_ID:your-google-client-id}
+      client-secret: ${GOOGLE_CLIENT_SECRET:your-google-client-secret}
+      redirect-uri: ${GOOGLE_REDIRECT_URI:http://localhost:3000/auth/callback}
+
+    ios:
+      client-id: ${GOOGLE_IOS_CLIENT_ID:dummy}
+      client-secret: ${GOOGLE_IOS_CLIENT_SECRET:}
+      redirect-uri: ${GOOGLE_IOS_REDIRECT_URI:dummy}
     # 배포 시 환경변수 GOOGLE_REDIRECT_URI로 설정 필요
     # 로컬: http://localhost:3000/auth/callback
     # 프로덕션1: https://mingjaam.github.io/auth/callback
     # 프로덕션2: https://on-it.kro.kr/auth/callback
-    redirect-uri: ${GOOGLE_REDIRECT_URI:http://localhost:3000/auth/callback}
     token-uri: https://oauth2.googleapis.com/token
     resource-uri: https://www.googleapis.com/oauth2/v2/userinfo
-    login-uri: ${GOOGLE_LOGIN_URI:https://accounts.google.com/o/oauth2/v2/auth}
 
 management:
   endpoints:


### PR DESCRIPTION
### 변경사항
- `oauth2.google.web` 구조로 설정 통일
- 누락되어 있던 `oauth2.google.ios` 설정 추가
- Google OAuth 관련 placeholder 오류 해결