### PR TITLE
refactor: iOS 구글 로그인 지원 및 OAuth 로직 수정

### DIFF
--- a/src/main/java/com/capstone/global/oauth/service/GoogleService.java
+++ b/src/main/java/com/capstone/global/oauth/service/GoogleService.java
@@ -36,9 +36,6 @@ public class GoogleService {
   @Value("${oauth2.google.ios.client-id}")
   private String iosClientId;
 
-  @Value("${oauth2.google.ios.client-secret:}")
-  private String iosClientSecret;
-
   @Value("${oauth2.google.token-uri}")
   private String tokenUri;
 
@@ -111,12 +108,15 @@ public class GoogleService {
 
   private String getAccessToken(String code, String dynamicRedirectUri, boolean isIos) {
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-    params.add("code", code);
-    String selectedClientId = isIos ? iosClientId : clientId;
-    String selectedClientSecret = isIos ? iosClientSecret : clientSecret;
 
+    params.add("code", code);
+
+    String selectedClientId = isIos ? iosClientId : clientId;
     params.add("client_id", selectedClientId);
-    params.add("client_secret", selectedClientSecret);
+    if (!isIos) {
+      params.add("client_secret", clientSecret);
+    }
+
     params.add("redirect_uri", dynamicRedirectUri);
     params.add("grant_type", "authorization_code");
 


### PR DESCRIPTION
### 변경사항
1. iOS 전용 구글 OAuth 인증 로직 반영
문제 상황: iOS 클라이언트는 구글 정책상 "Public Client"로 분류되어 `client_secret`을 발행하지 않으며, 토큰 요청 시 이 파라미터가 포함되면 구글 서버에서 에러를 반환하였습니다.
해결 방법: `GoogleService.getAccessToken()` 메서드 내에 isIos 플래그를 추가하여, iOS 요청일 경우 `client_secret`을 파라미터에서 제외하도록 수정했습니다

2. 플랫폼별 Client ID 동적 처리
`platform` 파라미터 값에 따라 `webClientId`와 `iosClientId` 중 적절한 ID를 선택하여 구글 서버로 전달하도록 개선했습니다.

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 