### PR TITLE
feat: Apple 로그인 기능 구현 및 배포 설정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -228,6 +228,8 @@ jobs:
           GOOGLE_IOS_REDIRECT_URI: ${{ secrets.GOOGLE_IOS_REDIRECT_URI }}
           WORKSPACE_INVITE_BASE_URL: ${{ secrets.WORKSPACE_INVITE_BASE_URL }}
           APP_FILE_BASE_URL: ${{ secrets.APP_FILE_BASE_URL }}
+          APPLE_BUNDLE_ID: ${{ secrets.APPLE_BUNDLE_ID }}
+          APPLE_PUBLIC_KEY_URL: "https://appleid.apple.com/auth/keys"
         run: |
           ssh -o StrictHostKeyChecking=no ec2-user@${{ secrets.AWS_SERVER_HOST }} "cat > ~/capstone-app/.env << 'ENVEOF'
           GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
@@ -238,6 +240,8 @@ jobs:
           GOOGLE_IOS_REDIRECT_URI=${{ secrets.GOOGLE_IOS_REDIRECT_URI }}
           WORKSPACE_INVITE_BASE_URL=${{ secrets.WORKSPACE_INVITE_BASE_URL }}
           APP_FILE_BASE_URL=${{ secrets.APP_FILE_BASE_URL }}
+          APPLE_BUNDLE_ID=${{ secrets.APPLE_BUNDLE_ID }}
+          APPLE_PUBLIC_KEY_URL=https://appleid.apple.com/auth/keys
           ENVEOF
           chmod 600 ~/capstone-app/.env && echo '✅ Environment variables file created'"
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     runtimeOnly 'org.postgresql:postgresql'
 
+    // APPLE 로그인 공개키 검증용
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.37.3'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/main/java/com/capstone/global/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/global/config/SecurityConfig.java
@@ -98,7 +98,7 @@ public class SecurityConfig {
     // 구성 파일 기반 허용 Origin 적용
     configuration.setAllowedOriginPatterns(appProperties.getAllowedOrigins());
     configuration.setAllowedOriginPatterns(
-        List.of("https://*.ngrok-free.dev", "http://localhost:3000", "https://on-it.kro.kr"));
+        List.of("http://localhost:3000", "https://on-it.kro.kr"));
     configuration.setAllowedMethods(
         Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
     configuration.setAllowedMethods(List.of("*"));

--- a/src/main/java/com/capstone/global/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/global/config/SecurityConfig.java
@@ -43,6 +43,10 @@ public class SecurityConfig {
             .requestMatchers("/api/v1/auth-google/**").permitAll()
             .requestMatchers("/v1/auth-google/**").permitAll()
 
+            // Apple OAuth
+            .requestMatchers("/api/v1/auth-apple/**").permitAll()
+            .requestMatchers("/v1/auth-apple/**").permitAll()
+
             // User info
             .requestMatchers("/v1/users/me").permitAll()
 

--- a/src/main/java/com/capstone/global/exception/ErrorCode.java
+++ b/src/main/java/com/capstone/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
   FORBIDDEN_WORKSPACE_ACCESS("워크스페이스 소속 사용자가 아닙니다.", HttpStatus.FORBIDDEN),
   FORBIDDEN_CLOSED_SESSION("이미 종료된 세션에는 참여할 수 없습니다.", HttpStatus.FORBIDDEN),
 
+  APPLE_AUTH_FAILED("Apple 인증 처리 중 오류가 발생했습니다.", HttpStatus.UNAUTHORIZED),
   UNAUTHORIZED_USER("인증 정보가 필요합니다.", HttpStatus.UNAUTHORIZED),
   INVALID_TOKEN("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
 

--- a/src/main/java/com/capstone/global/oauth/AppleJwtValidator.java
+++ b/src/main/java/com/capstone/global/oauth/AppleJwtValidator.java
@@ -1,0 +1,81 @@
+package com.capstone.global.oauth;
+
+import static com.capstone.global.exception.ErrorCode.INVALID_TOKEN;
+
+import com.capstone.global.exception.CustomException;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.SignedJWT;
+import java.net.URI;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URL;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class AppleJwtValidator {
+
+  @Value("${apple.bundle-id}")
+  private String appleBundleId;
+
+  @Value("${apple.public-key-url}")
+  private String applePublicKeyUrl;
+
+  public Map<String, Object> validateAndGetClaims(String identityToken) throws Exception {
+    SignedJWT signedJWT = SignedJWT.parse(identityToken);
+
+    if (!verifySignature(signedJWT)) {
+      throw new CustomException(INVALID_TOKEN);
+    }
+
+    Map<String, Object> claims = signedJWT.getJWTClaimsSet().getClaims();
+
+    Date exp = signedJWT.getJWTClaimsSet().getExpirationTime();
+    if (exp == null || exp.before(new Date())) {
+      throw new CustomException(INVALID_TOKEN);
+    }
+
+    if (!"https://appleid.apple.com".equals(claims.get("iss"))) {
+      throw new IllegalArgumentException("잘못된 토큰 발행자입니다.");
+    }
+
+    validateAudience(claims.get("aud"));
+
+    return claims;
+  }
+
+  private boolean verifySignature(SignedJWT signedJWT) throws Exception {
+    URL applePublicKeysUrl = URI.create(applePublicKeyUrl).toURL();
+
+    JWKSet jwkSet = JWKSet.load(applePublicKeysUrl);
+    String kid = signedJWT.getHeader().getKeyID();
+    RSAKey rsaKey = (RSAKey) jwkSet.getKeyByKeyId(kid);
+
+    if (rsaKey == null) {
+      return false;
+    }
+
+    RSASSAVerifier verifier = new RSASSAVerifier(rsaKey.toRSAPublicKey());
+    return signedJWT.verify(verifier);
+  }
+
+  private void validateAudience(Object audClaim) {
+    boolean isValid = false;
+    if (audClaim instanceof String) {
+      isValid = appleBundleId.equals(audClaim);
+    } else if (audClaim instanceof List) {
+      isValid = ((List<?>) audClaim).contains(appleBundleId);
+    }
+
+    if (!isValid) {
+      log.error("Audience 검증 실패. 기대값: {}, 실제값: {}", appleBundleId, audClaim);
+      throw new CustomException(INVALID_TOKEN);
+    }
+  }
+}

--- a/src/main/java/com/capstone/global/oauth/AppleLoginRequest.java
+++ b/src/main/java/com/capstone/global/oauth/AppleLoginRequest.java
@@ -1,0 +1,9 @@
+package com.capstone.global.oauth;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AppleLoginRequest(
+    @NotBlank(message = "Identity token은 필수입니다")
+    String identityToken,
+    String fullName
+) {}

--- a/src/main/java/com/capstone/global/oauth/controller/AppleController.java
+++ b/src/main/java/com/capstone/global/oauth/controller/AppleController.java
@@ -1,0 +1,29 @@
+package com.capstone.global.oauth.controller;
+
+import com.capstone.global.oauth.AppleLoginRequest;
+import com.capstone.global.oauth.TokenDto;
+import com.capstone.global.oauth.service.AppleService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/auth-apple")
+@RequiredArgsConstructor
+public class AppleController {
+
+  private final AppleService appleService;
+
+  @PostMapping
+  public ResponseEntity<TokenDto> loginOrJoin(@RequestBody @Valid AppleLoginRequest req) {
+
+    log.info("Apple 로그인 요청 수신");
+    return ResponseEntity.ok(appleService.loginOrJoin(req.identityToken(), req.fullName()));
+  }
+}

--- a/src/main/java/com/capstone/global/oauth/service/AppleService.java
+++ b/src/main/java/com/capstone/global/oauth/service/AppleService.java
@@ -1,0 +1,73 @@
+package com.capstone.global.oauth.service;
+
+import static com.capstone.global.exception.ErrorCode.*;
+
+import com.capstone.domain.user.User;
+import com.capstone.domain.user.UserRepository;
+import com.capstone.global.exception.CustomException;
+import com.capstone.global.oauth.AppleJwtValidator;
+import com.capstone.global.oauth.JwtProvider;
+import com.capstone.global.oauth.TokenDto;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppleService {
+
+  private final UserRepository userRepository;
+  private final JwtProvider jwtProvider;
+  private final AppleJwtValidator appleJwtValidator;
+
+  @Transactional
+  public TokenDto loginOrJoin(String identityToken, String fullName) { // fullName 파라미터 추가
+    try {
+      Map<String, Object> claims = appleJwtValidator.validateAndGetClaims(identityToken);
+
+      String email = (String) claims.get("email");
+
+      String name = (fullName != null && !fullName.isBlank())
+          ? fullName
+          : (claims.get("name") != null ? (String) claims.get("name") : email.split("@")[0]);
+
+      log.info("Apple 사용자 인증 성공: {}", email);
+
+      User user = userRepository.findByEmail(email.trim())
+          .orElseGet(() -> {
+            try {
+              return userRepository.save(User.builder()
+                  .email(email.trim())
+                  .name(name)
+                  .build());
+            } catch (DataIntegrityViolationException e) {
+              return userRepository.findByEmail(email.trim()).orElseThrow();
+            }
+          });
+
+      String accessToken = jwtProvider.createAccessToken(user.getId(), user.getEmail());
+      String refreshToken = jwtProvider.createRefreshToken(user.getId(), user.getEmail());
+
+      user.setRefreshToken(refreshToken);
+      userRepository.save(user);
+
+      return TokenDto.builder()
+          .accessToken(accessToken)
+          .refreshToken(refreshToken)
+          .name(user.getName())
+          .email(user.getEmail())
+          .build();
+
+    } catch (IllegalArgumentException e) {
+      log.error("Apple 토큰 검증 실패: {}", e.getMessage());
+      throw new CustomException(INVALID_TOKEN);
+    } catch (Exception e) {
+      log.error("Apple 로그인 처리 중 시스템 오류 발생", e);
+      throw new CustomException(APPLE_AUTH_FAILED);
+    }
+  }
+}

--- a/src/main/java/com/capstone/global/oauth/service/AppleService.java
+++ b/src/main/java/com/capstone/global/oauth/service/AppleService.java
@@ -25,7 +25,7 @@ public class AppleService {
   private final AppleJwtValidator appleJwtValidator;
 
   @Transactional
-  public TokenDto loginOrJoin(String identityToken, String fullName) { // fullName 파라미터 추가
+  public TokenDto loginOrJoin(String identityToken, String fullName) {
     try {
       Map<String, Object> claims = appleJwtValidator.validateAndGetClaims(identityToken);
 


### PR DESCRIPTION
### 변경사항
- Apple OAuth 인증
  - JWT 검증: 애플 서버에서 제공하는 공개키를 로드하여, 클라이언트가 보낸 `identityToken`의 위변조 여부를 확인합니다.
  - 보안 파라미터 검증: 토큰의 발행자, 유효기간, 그리고 번들 ID가 일치하는지 확인합니다.
- AppleController 및 DTO 
  - `POST /v1/auth-apple`
    - `identityToken`과 `fullName`을 `RequestBody`로 수신
    - `@Valid`를 도입하여 필수 데이터인 토큰 누락 시 예외 처리
  - AppleLoginRequest: 불변 객체인 `Java Record`를 사용하여 요청 데이터 구조를 정의하고 유효성 검사 어노테이션을 적용
- AppleService
  - 사용자 매핑 및 이름 처리
    - 애플 로그인 특성상 fullName은 최초 1회만 제공되므로, 전달받지 못했을 경우 토큰 내 name 클레임이나 이메일 아이디 부분을 활용해 이름을 자동 생성
  - 자동 가입 및 로그인
    - `DataIntegrityViolationException` 처리를 통해 동시성 상황에서도 중복 가입 없이 안정적으로 유저 정보를 저장하거나 조회
  - 인증 성공 시 서비스 전용 `accessToken`과 `refreshToken`을 생성하여 반환
- SecurityConfig 및 인프라 설정 업데이트
  - `/v1/auth-apple/**` 및 `/api/v1/auth-apple/**` 경로에 대해 `permitAll()` 설정을 추가하여 인증 전 로그인이 가능하도록 설정
  - CI/CD 환경 변수 연동: GitHub Actions 배포 프로세스 내에 `APPLE_BUNDLE_ID` 및 `APPLE_PUBLIC_KEY_URL`을 주입
- 테스트 코드는 추후 업데이트 예정
  
  ### 테스트
- [ ] 테스트 코드
- [ ] API 테스트 