### PR TITLE
fix: default APP_DEV_BOOTSTRAP_AUTH when secret is empty

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -232,8 +232,13 @@ jobs:
           APPLE_BUNDLE_ID: ${{ secrets.APPLE_BUNDLE_ID }}
           APPLE_PUBLIC_KEY_URL: "https://appleid.apple.com/auth/keys"
         run: |
+          APP_DEV_BOOTSTRAP_AUTH_VALUE="${{ secrets.APP_DEV_BOOTSTRAP_AUTH }}"
+          if [ -z "$APP_DEV_BOOTSTRAP_AUTH_VALUE" ]; then
+            APP_DEV_BOOTSTRAP_AUTH_VALUE=true
+          fi
+
           ssh -o StrictHostKeyChecking=no ec2-user@${{ secrets.AWS_SERVER_HOST }} "cat > ~/capstone-app/.env << 'ENVEOF'
-          APP_DEV_BOOTSTRAP_AUTH=${{ secrets.APP_DEV_BOOTSTRAP_AUTH }}
+          APP_DEV_BOOTSTRAP_AUTH=${APP_DEV_BOOTSTRAP_AUTH_VALUE}
           GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
           GOOGLE_REDIRECT_URI=${{ secrets.GOOGLE_REDIRECT_URI }}


### PR DESCRIPTION
## Summary
- CI 배포 시 `APP_DEV_BOOTSTRAP_AUTH` 시크릿이 비어 있으면 `true` 기본값을 사용하도록 수정했습니다.
- 빈 값 주입으로 발생하던 Spring boolean 바인딩 실패를 방지했습니다.
- 서버 기존 DB 구동 흐름은 그대로 유지됩니다.

## Test
- [ ] CI 배포 실행
- [ ] `/api/v1/health` 200 확인
- [ ] 서버 로그에 `app.dev-bootstrap-auth.enabled` 바인딩 오류 미발생 확인