### PR TITLE
test: Google OAuth 로그인 및 로그인 URI 관련 테스트 코드 추가

### DIFF
--- a/src/test/java/com/capstone/controller/GoogleControllerTest.java
+++ b/src/test/java/com/capstone/controller/GoogleControllerTest.java
@@ -13,15 +13,13 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.Map;
 
 @WebMvcTest(GoogleController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -37,38 +35,102 @@ class GoogleControllerTest {
   private AppProperties appProperties;
 
   @Test
-  @DisplayName("로그인 & 회원가입 성공 테스트")
+  @DisplayName("웹 로그인 성공 - redirect_uri 파라미터 직접 전달")
   void successLoginOrJoin() throws Exception {
-
     TokenDto tokenDto = TokenDto.builder()
         .accessToken("access")
         .refreshToken("refresh")
+        .name("cap")
+        .email("capstone@test.com")
         .build();
 
-    given(appProperties.getOauthRedirectMap()).willReturn(Map.of("localhost", "http://localhost:3000/auth/callback"));
-    given(appProperties.getDefaultRedirectUri()).willReturn("http://localhost:3000/auth/callback");
-    given(googleService.loginOrJoin(anyString(), anyString())).willReturn(tokenDto);
+    given(googleService.loginOrJoin(anyString(), anyString(), eq(false))).willReturn(tokenDto);
 
     mockMvc.perform(post("/v1/auth-google")
-            .param("code", "Wrong Code")
+            .param("code", "auth-code")
+            .param("redirect_uri", "http://localhost:3000/auth/callback")
+            .param("platform", "web")
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.accessToken").value("access"))
-        .andExpect(jsonPath("$.refreshToken").value("refresh"));
+        .andExpect(jsonPath("$.refreshToken").value("refresh"))
+        .andExpect(jsonPath("$.name").value("cap"))
+        .andExpect(jsonPath("$.email").value("capstone@test.com"));
+  }
+
+  @Test
+  @DisplayName("iOS 로그인 성공 - platform=ios")
+  void successIosLoginOrJoin() throws Exception {
+    TokenDto tokenDto = TokenDto.builder()
+        .accessToken("ios-access")
+        .refreshToken("ios-refresh")
+        .name("ioscap")
+        .email("capstone@test.com")
+        .build();
+
+    given(googleService.loginOrJoin(anyString(), anyString(), eq(true))).willReturn(tokenDto);
+
+    mockMvc.perform(post("/v1/auth-google")
+            .param("code", "ios-auth-code")
+            .param("redirect_uri", "com.googleusercontent.apps.test:/oauth")
+            .param("platform", "ios")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accessToken").value("ios-access"))
+        .andExpect(jsonPath("$.refreshToken").value("ios-refresh"));
+  }
+
+  @Test
+  @DisplayName("로그인 실패 - 구글 인증 오류로 5xx 반환")
+  void failLoginOrJoin() throws Exception {
+    given(appProperties.getOauthRedirectMap()).willReturn(Map.of());
+    given(appProperties.getDefaultRedirectUri()).willReturn("http://localhost:3000/auth/callback");
+    given(googleService.loginOrJoin(anyString(), anyString(), anyBoolean()))
+        .willThrow(new RuntimeException("구글 인증 실패"));
+
+    mockMvc.perform(post("/v1/auth-google")
+            .param("code", "wrong-code")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().is5xxServerError());
   }
 
 
   @Test
-  @DisplayName("로그인 & 회원가입 실패 테스트")
-  void failLoginOrJoin() throws Exception {
-    when(appProperties.getOauthRedirectMap()).thenReturn(Map.of());
-    when(appProperties.getDefaultRedirectUri()).thenReturn("http://localhost:3000/auth/callback");
-    when(googleService.loginOrJoin(anyString(), anyString()))
-        .thenThrow(new RuntimeException("구글 인증 실패"));
+  @DisplayName("웹 로그인 URI 조회 성공")
+  void successGetWebLoginUri() throws Exception {
+    mockMvc.perform(get("/v1/auth-google/login-uri")
+            .param("redirect_uri", "http://localhost:3000/auth/callback")
+            .param("platform", "web"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(org.hamcrest.Matchers.containsString("accounts.google.com")))
+        .andExpect(content().string(org.hamcrest.Matchers.containsString("redirect_uri")));
+  }
 
-    mockMvc.perform(post("/v1/auth-google")
-            .param("code", "Wrong Code")
-            .contentType(MediaType.APPLICATION_JSON))
+  @Test
+  @DisplayName("iOS 로그인 URI 조회 성공")
+  void successGetIosLoginUri() throws Exception {
+    mockMvc.perform(get("/v1/auth-google/login-uri")
+            .param("redirect_uri", "com.googleusercontent.apps.test:/oauth")
+            .param("platform", "ios"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(org.hamcrest.Matchers.containsString("accounts.google.com")));
+  }
+
+  @Test
+  @DisplayName("로그인 URI 조회 실패 - iOS인데 웹 형식 redirect_uri 전달")
+  void failGetIosLoginUri() throws Exception {
+    mockMvc.perform(get("/v1/auth-google/login-uri")
+            .param("redirect_uri", "http://localhost:3000/auth/callback")
+            .param("platform", "ios"))
+        .andExpect(status().is5xxServerError());
+  }
+
+  @Test
+  @DisplayName("로그인 URI 조회 실패 - 웹인데 iOS 형식 redirect_uri 전달")
+  void failGetWebLoginUri() throws Exception {
+    mockMvc.perform(get("/v1/auth-google/login-uri")
+            .param("redirect_uri", "com.googleusercontent.apps.test:/oauth")
+            .param("platform", "web"))
         .andExpect(status().is5xxServerError());
   }
 }

--- a/src/test/java/com/capstone/service/GoogleServiceTest.java
+++ b/src/test/java/com/capstone/service/GoogleServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.*;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
@@ -43,22 +44,20 @@ class GoogleServiceTest {
 
   @BeforeEach
   void setUp() {
-    ReflectionTestUtils.setField(googleService, "clientId", "capstone-id");
+    ReflectionTestUtils.setField(googleService, "clientId", "capstone-web-client-id");
     ReflectionTestUtils.setField(googleService, "clientSecret", "capstone-secret");
+    ReflectionTestUtils.setField(googleService, "iosClientId", "capstone-ios-client-id");
     ReflectionTestUtils.setField(googleService, "tokenUri", "http://capstone-token-uri");
     ReflectionTestUtils.setField(googleService, "resourceUri", "http://capstone-resource-uri");
 
-    when(jwtProvider.createAccessToken(anyLong(), anyString())).thenReturn("access");
-    when(jwtProvider.createRefreshToken(anyLong(), anyString())).thenReturn("refresh");
-
     lenient().when(jwtProvider.createAccessToken(anyLong(), anyString())).thenReturn("access");
-    lenient().when(jwtProvider.createRefreshToken(anyLong(), anyString()))
-        .thenReturn("refresh");
+    lenient().when(jwtProvider.createRefreshToken(anyLong(), anyString())).thenReturn("refresh");
   }
 
+
   @Test
-  @DisplayName("로그인 & 회원가입 성공 테스트")
-  void successLoginOrJoin() throws Exception {
+  @DisplayName("웹 로그인 성공 - 기존 유저")
+  void successWebExistingUserLoginOrJoin() throws Exception {
     User existingUser = User.builder()
         .id(1L)
         .email("capstone@test.com")
@@ -78,30 +77,171 @@ class GoogleServiceTest {
         .thenReturn(new ResponseEntity<>(userInfoResponse, HttpStatus.OK));
 
     when(userRepository.findByEmail("capstone@test.com")).thenReturn(Optional.of(existingUser));
-    when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
-    TokenDto tokenDto = googleService.loginOrJoin("auth-code", "http://localhost/capstone");
+    TokenDto result = googleService.loginOrJoin("auth-code", "http://localhost/callback", false);
 
-    assertNotNull(tokenDto);
-    assertEquals("access", tokenDto.getAccessToken());
-    assertEquals("refresh", tokenDto.getRefreshToken());
+    assertNotNull(result);
+    assertEquals("access", result.getAccessToken());
+    assertEquals("refresh", result.getRefreshToken());
+    assertEquals("cap", result.getName());
+    assertEquals("capstone@test.com", result.getEmail());
 
     verify(userRepository, times(1)).findByEmail("capstone@test.com");
     verify(userRepository, times(1)).save(existingUser);
   }
 
   @Test
-  @DisplayName("로그인 & 회원가입 실패 테스트")
-  void failLoginOrJoin() {
-    when(restTemplate.exchange(
-        anyString(),
-        eq(HttpMethod.POST),
-        any(HttpEntity.class),
-        eq(JsonNode.class)
-    )).thenThrow(new RuntimeException("capstone-token-uri 실패"));
+  @DisplayName("웹 로그인 성공 - 신규 유저 가입")
+  void successWebNewUserLoginOrJoin() throws Exception {
+    JsonNode tokenResponse = objectMapper.readTree("{\"access_token\":\"mock-access-token\"}");
+    when(restTemplate.exchange(eq("http://capstone-token-uri"), eq(HttpMethod.POST),
+        any(HttpEntity.class), eq(JsonNode.class)))
+        .thenReturn(new ResponseEntity<>(tokenResponse, HttpStatus.OK));
 
-    RuntimeException exception = assertThrows(RuntimeException.class,
-        () -> googleService.loginOrJoin("code", "http://localhost/capstone"));
-    assertEquals("capstone-token-uri 실패", exception.getMessage());
+    JsonNode userInfoResponse = objectMapper.readTree(
+        "{\"email\":\"new@test.com\",\"name\":\"newbie\",\"picture\":\"pic.png\"}");
+    when(restTemplate.exchange(eq("http://capstone-resource-uri"), eq(HttpMethod.GET),
+        any(HttpEntity.class), eq(JsonNode.class)))
+        .thenReturn(new ResponseEntity<>(userInfoResponse, HttpStatus.OK));
+
+    when(userRepository.findByEmail("new@test.com")).thenReturn(Optional.empty());
+    when(userRepository.save(any(User.class))).thenAnswer(inv -> {
+      User u = inv.getArgument(0);
+      return User.builder()
+          .id(2L)
+          .email(u.getEmail())
+          .name(u.getName())
+          .profileImage(u.getProfileImage())
+          .build();
+    });
+
+    TokenDto result = googleService.loginOrJoin("auth-code", "http://localhost/callback", false);
+
+    assertNotNull(result);
+    assertEquals("access", result.getAccessToken());
+    assertEquals("newbie", result.getName());
+    assertEquals("new@test.com", result.getEmail());
+
+    verify(userRepository, times(2)).save(any(User.class));
+  }
+
+  @Test
+  @DisplayName("웹 로그인 성공 - 동시 요청으로 중복 저장 시도 시 기존 유저 조회로 복구")
+  void successWebDuplicateLoginOrJoin() throws Exception {
+    User existingUser = User.builder()
+        .id(3L)
+        .email("dup@test.com")
+        .name("dupuser")
+        .build();
+
+    JsonNode tokenResponse = objectMapper.readTree("{\"access_token\":\"mock-access-token\"}");
+    when(restTemplate.exchange(eq("http://capstone-token-uri"), eq(HttpMethod.POST),
+        any(HttpEntity.class), eq(JsonNode.class)))
+        .thenReturn(new ResponseEntity<>(tokenResponse, HttpStatus.OK));
+
+    JsonNode userInfoResponse = objectMapper.readTree(
+        "{\"email\":\"dup@test.com\",\"name\":\"dupuser\",\"picture\":null}");
+    when(restTemplate.exchange(eq("http://capstone-resource-uri"), eq(HttpMethod.GET),
+        any(HttpEntity.class), eq(JsonNode.class)))
+        .thenReturn(new ResponseEntity<>(userInfoResponse, HttpStatus.OK));
+
+    when(userRepository.findByEmail("dup@test.com"))
+        .thenReturn(Optional.empty())
+        .thenReturn(Optional.of(existingUser));
+    when(userRepository.save(any(User.class)))
+        .thenThrow(new DataIntegrityViolationException("duplicate"))
+        .thenAnswer(inv -> inv.getArgument(0));
+
+    TokenDto result = googleService.loginOrJoin("auth-code", "http://localhost/callback", false);
+
+    assertNotNull(result);
+    assertEquals("dupuser", result.getName());
+    verify(userRepository, times(2)).findByEmail("dup@test.com");
+  }
+
+  @Test
+  @DisplayName("iOS 로그인 성공 - client_secret 없이 iosClientId 사용")
+  void successIosNoClientSecreteLoginOrJoin() throws Exception {
+    User existingUser = User.builder()
+        .id(4L)
+        .email("ios@test.com")
+        .name("iosCap")
+        .build();
+
+    JsonNode tokenResponse = objectMapper.readTree("{\"access_token\":\"ios-mock-token\"}");
+    when(restTemplate.exchange(eq("http://capstone-token-uri"), eq(HttpMethod.POST),
+        any(HttpEntity.class), eq(JsonNode.class)))
+        .thenReturn(new ResponseEntity<>(tokenResponse, HttpStatus.OK));
+
+    JsonNode userInfoResponse = objectMapper.readTree(
+        "{\"email\":\"ios@test.com\",\"name\":\"iosCap\",\"picture\":\"ios.png\"}");
+    when(restTemplate.exchange(eq("http://capstone-resource-uri"), eq(HttpMethod.GET),
+        any(HttpEntity.class), eq(JsonNode.class)))
+        .thenReturn(new ResponseEntity<>(userInfoResponse, HttpStatus.OK));
+
+    when(userRepository.findByEmail("ios@test.com")).thenReturn(Optional.of(existingUser));
+    when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    TokenDto result = googleService.loginOrJoin(
+        "ios-auth-code", "com.googleusercontent.apps.test:/oauth", true);
+
+    assertNotNull(result);
+    assertEquals("access", result.getAccessToken());
+    assertEquals("iosCap", result.getName());
+  }
+
+  @Test
+  @DisplayName("실패 - 토큰 URI 호출 오류")
+  void failTokenURILoginOrJoin() {
+    when(restTemplate.exchange(
+        anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(JsonNode.class)))
+        .thenThrow(new RuntimeException("capstone-token-uri 실패"));
+
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> googleService.loginOrJoin("code", "http://localhost/callback", false));
+    assertEquals("capstone-token-uri 실패", ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("실패 - 사용자 정보 URI 호출 오류")
+  void failUserURILoginOrJoin() throws Exception {
+    JsonNode tokenResponse = objectMapper.readTree("{\"access_token\":\"mock-access-token\"}");
+    when(restTemplate.exchange(eq("http://capstone-token-uri"), eq(HttpMethod.POST),
+        any(HttpEntity.class), eq(JsonNode.class)))
+        .thenReturn(new ResponseEntity<>(tokenResponse, HttpStatus.OK));
+
+    when(restTemplate.exchange(eq("http://capstone-resource-uri"), eq(HttpMethod.GET),
+        any(HttpEntity.class), eq(JsonNode.class)))
+        .thenThrow(new RuntimeException("capstone-resource-uri 실패"));
+
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> googleService.loginOrJoin("code", "http://localhost/callback", false));
+    assertEquals("capstone-resource-uri 실패", ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("실패 - 중복 저장 후 재조회도 실패하면 예외 발생")
+  void failDuplicateLoginOrJoin() throws Exception {
+    JsonNode tokenResponse = objectMapper.readTree("{\"access_token\":\"mock-access-token\"}");
+    when(restTemplate.exchange(eq("http://capstone-token-uri"), eq(HttpMethod.POST),
+        any(HttpEntity.class), eq(JsonNode.class)))
+        .thenReturn(new ResponseEntity<>(tokenResponse, HttpStatus.OK));
+
+    JsonNode userInfoResponse = objectMapper.readTree(
+        "{\"email\":\"fail@test.com\",\"name\":\"failuser\",\"picture\":null}");
+    when(restTemplate.exchange(eq("http://capstone-resource-uri"), eq(HttpMethod.GET),
+        any(HttpEntity.class), eq(JsonNode.class)))
+        .thenReturn(new ResponseEntity<>(userInfoResponse, HttpStatus.OK));
+
+    when(userRepository.findByEmail("fail@test.com"))
+        .thenReturn(Optional.empty())
+        .thenReturn(Optional.empty());
+
+    when(userRepository.save(any(User.class)))
+        .thenThrow(new DataIntegrityViolationException("duplicate"));
+
+    assertThrows(RuntimeException.class,
+        () -> googleService.loginOrJoin("code", "http://localhost/callback", false));
   }
 }


### PR DESCRIPTION
### 변경사항

- GoogleControllerTest

  * 웹 로그인 성공: redirect_uri 파라미터를 직접 전달했을 때 accessToken, refreshToken, 사용자 정보가 정상 반환되는지 확인
  * iOS 로그인 성공: platform=ios 요청 시 iOS 전용 redirect_uri를 사용하여 정상 로그인되는지 확인
  * 로그인 실패: Google 인증 과정에서 예외 발생 시 5xx 응답이 반환되는지 확인
  * 웹 로그인 URI 조회 성공: 웹 플랫폼용 로그인 URI가 정상 생성되는지 확인
  * iOS 로그인 URI 조회 성공: iOS 플랫폼용 로그인 URI가 정상 생성되는지 확인
  * 로그인 URI 조회 실패: iOS 요청에 웹 형식 redirect_uri 전달 시 예외가 발생하는지 확인
  * 로그인 URI 조회 실패: 웹 요청에 iOS 형식 redirect_uri 전달 시 예외가 발생하는지 확인

- GoogleServiceTest

  * 웹 로그인 성공(기존 유저): 기존 회원 로그인 시 JWT 토큰이 정상 생성되고 사용자 정보가 반환되는지 확인
  * 웹 로그인 성공(신규 유저 가입): 신규 회원 로그인 시 회원가입과 토큰 발급이 정상 처리되는지 확인
  * 웹 로그인 성공(중복 저장 복구): 동시 요청으로 중복 저장 예외 발생 시 기존 회원 조회로 정상 복구되는지 확인
  * iOS 로그인 성공: iOS clientId 기반 로그인 시 client_secret 없이 정상 인증되는지 확인
  * 로그인 실패(토큰 URI 오류): Google 토큰 요청 실패 시 RuntimeException이 발생하는지 확인
  * 로그인 실패(사용자 정보 조회 오류): 사용자 정보 요청 실패 시 RuntimeException이 발생하는지 확인
  * 로그인 실패(중복 저장 후 재조회 실패): 중복 저장 이후 사용자 재조회에도 실패할 경우 예외가 발생하는지 확인

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [ ] API 테스트 