### PR TITLE
test: user controller & service 테스트 코드 작성

### DIFF
--- a/src/test/java/com/capstone/controller/UserControllerTest.java
+++ b/src/test/java/com/capstone/controller/UserControllerTest.java
@@ -1,0 +1,137 @@
+package com.capstone.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.capstone.domain.user.UserController;
+import com.capstone.domain.user.UserResponse;
+import com.capstone.domain.user.UserService;
+import com.capstone.domain.user.UserUpdateRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class UserControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private UserService userService;
+
+  private final String VALID_TOKEN = "Bearer 테스트 토큰";
+  private final String RAW_TOKEN = "테스트 토큰";
+
+  @Test
+  @DisplayName(" 올바른 JWT 토큰으로 조회 시 사용자 정보를 반환 성공")
+  void successGet() throws Exception {
+    UserResponse expectedResponse = UserResponse.builder()
+        .id(1L)
+        .email("테스트 메일")
+        .name("테스트 이름")
+        .profileImage("사진")
+        .build();
+
+    given(userService.getCurrentUser(RAW_TOKEN)).willReturn(expectedResponse);
+
+    mockMvc.perform(get("/v1/users/me")
+            .header(HttpHeaders.AUTHORIZATION, VALID_TOKEN))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1L))
+        .andExpect(jsonPath("$.email").value("테스트 메일"))
+        .andExpect(jsonPath("$.name").value("테스트 이름"))
+        .andExpect(jsonPath("$.profileImage").value("사진"))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("토큰 헤더 형식이 올바르지 않으면 401 에러 - 실패")
+  void failGet() throws Exception {
+    String INVALID_TOKEN = "Invalid 토큰";
+    mockMvc.perform(get("/v1/users/me")
+            .header(HttpHeaders.AUTHORIZATION, INVALID_TOKEN))
+        .andExpect(status().isUnauthorized())
+        .andDo(print());
+  }
+
+
+  @Test
+  @DisplayName("요청 데이터가 올바르면 사용자 정보 수정 성공")
+  void successUpdate() throws Exception {
+    UserUpdateRequest request = new UserUpdateRequest();
+    request.setName("수정된이름");
+    request.setProfileImage("새로운 사진");
+
+    UserResponse expectedResponse = UserResponse.builder()
+        .id(1L)
+        .email("테스트 메일")
+        .name("수정된이름")
+        .profileImage("새로운 사진")
+        .build();
+
+    given(userService.updateUser(eq(RAW_TOKEN), any(UserUpdateRequest.class)))
+        .willReturn(expectedResponse);
+
+    mockMvc.perform(patch("/v1/users/me")
+            .header(HttpHeaders.AUTHORIZATION, VALID_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.name").value("수정된이름"))
+        .andExpect(jsonPath("$.profileImage").value("새로운 사진"))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("토큰 헤더 없이 수정을 요청하면 401 에러 - 실패")
+  void failUpdate() throws Exception {
+    UserUpdateRequest request = new UserUpdateRequest();
+    request.setName("새로운 이름");
+
+    mockMvc.perform(patch("/v1/users/me")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isUnauthorized())
+        .andDo(print());
+  }
+
+
+  @Test
+  @DisplayName("회원 탈퇴 처리가 완료되면 204 No Content를 반환 성공")
+  void successDelete() throws Exception {
+    doNothing().when(userService).deleteUser(RAW_TOKEN);
+
+    mockMvc.perform(delete("/v1/users/me")
+            .header(HttpHeaders.AUTHORIZATION, VALID_TOKEN))
+        .andExpect(status().isNoContent())
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("토큰 헤더가 누락되면 401 에러 - 실패")
+  void failDelete() throws Exception {
+    mockMvc.perform(delete("/v1/users/me"))
+        .andExpect(status().isUnauthorized())
+        .andDo(print());
+  }
+}

--- a/src/test/java/com/capstone/service/UserServiceTest.java
+++ b/src/test/java/com/capstone/service/UserServiceTest.java
@@ -1,0 +1,155 @@
+package com.capstone.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.capstone.domain.user.User;
+import com.capstone.domain.user.UserRepository;
+import com.capstone.domain.user.UserResponse;
+import com.capstone.domain.user.UserService;
+import com.capstone.domain.user.UserUpdateRequest;
+import com.capstone.domain.workspace.WorkspaceRepository;
+import com.capstone.domain.workspaceInvitation.WorkspaceInvitationRepository;
+import com.capstone.domain.workspaceInvite.WorkspaceInviteRepository;
+import com.capstone.domain.workspaceUser.WorkspaceUserRepository;
+import com.capstone.global.exception.CustomException;
+import com.capstone.global.exception.ErrorCode;
+import com.capstone.global.oauth.JwtProvider;
+import io.jsonwebtoken.JwtException;
+import java.util.ArrayList;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+  @InjectMocks
+  private UserService userService;
+
+  @Mock
+  private UserRepository userRepository;
+  @Mock
+  private WorkspaceUserRepository workspaceUserRepository;
+  @Mock
+  private WorkspaceInviteRepository workspaceInviteRepository;
+  @Mock
+  private WorkspaceInvitationRepository workspaceInvitationRepository;
+  @Mock
+  private WorkspaceRepository workspaceRepository;
+
+  @Mock
+  private JwtProvider jwtProvider;
+
+  private final String RAW_TOKEN = "테스트 토큰";
+  private final Long USER_ID = 1L;
+
+  @Test
+  @DisplayName("현재 사용자 정보 조회 성공")
+  void successGet() {
+    User user = User.builder()
+        .id(USER_ID)
+        .email("테스트 메일")
+        .name("테스트 이름")
+        .profileImage("테스트 사진")
+        .build();
+
+    given(jwtProvider.getUserIdFromAccessToken(RAW_TOKEN)).willReturn(USER_ID);
+    given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+    UserResponse response = userService.getCurrentUser(RAW_TOKEN);
+
+    assertThat(response).isNotNull();
+    assertThat(response.getId()).isEqualTo(USER_ID);
+    assertThat(response.getName()).isEqualTo("테스트 이름");
+  }
+
+  @Test
+  @DisplayName("현재 사용자 정보 조회 실패 - 유효하지 않은 토큰")
+  void failGet() {
+    given(jwtProvider.getUserIdFromAccessToken(RAW_TOKEN)).willThrow(new JwtException("만료된 토큰"));
+
+    assertThatThrownBy(() -> userService.getCurrentUser(RAW_TOKEN))
+        .isInstanceOf(CustomException.class)
+        .hasMessageContaining(ErrorCode.INVALID_TOKEN.getMessage());
+  }
+
+  @Test
+  @DisplayName("사용자 정보 수정 성공")
+  void successUpdate() {
+    User user = User.builder()
+        .id(USER_ID)
+        .name("이전 이름")
+        .profileImage("테스트 사진")
+        .build();
+
+    UserUpdateRequest request = new UserUpdateRequest();
+    request.setName("수정된 이름");
+    request.setProfileImage("새로운 사진");
+
+    given(jwtProvider.getUserIdFromAccessToken(RAW_TOKEN)).willReturn(USER_ID);
+    given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+    given(userRepository.saveAndFlush(any(User.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    UserResponse response = userService.updateUser(RAW_TOKEN, request);
+
+    assertThat(response.getName()).isEqualTo("수정된 이름");
+    assertThat(response.getProfileImage()).isEqualTo("새로운 사진");
+  }
+
+  @Test
+  @DisplayName("사용자 정보 수정 실패 - 존재하지 않는 유저")
+  void failUpdate() {
+    UserUpdateRequest request = new UserUpdateRequest();
+    request.setName("수정 이름");
+
+    given(jwtProvider.getUserIdFromAccessToken(RAW_TOKEN)).willReturn(USER_ID);
+    given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> userService.updateUser(RAW_TOKEN, request))
+        .isInstanceOf(CustomException.class)
+        .hasMessageContaining(ErrorCode.NOT_FOUND_USER.getMessage());
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 처리 성공")
+  void successDelete() {
+    User user = User.builder()
+        .id(USER_ID)
+        .refreshToken("존재 토큰")
+        .build();
+
+    given(jwtProvider.getUserIdFromAccessToken(RAW_TOKEN)).willReturn(USER_ID);
+    given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+    given(workspaceInvitationRepository.findByInvitedUserOrInvitedBy(user, user)).willReturn(
+        new ArrayList<>());
+    given(workspaceInviteRepository.findByCreatedBy(user)).willReturn(new ArrayList<>());
+    given(workspaceRepository.findByOwner(user)).willReturn(new ArrayList<>());
+    given(workspaceUserRepository.findByUser(user)).willReturn(new ArrayList<>());
+
+    userService.deleteUser(RAW_TOKEN);
+
+    assertThat(user.getRefreshToken()).isNull();
+    verify(userRepository).delete(user);
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 처리 실패 - 원본 예외가 그대로 던져짐")
+  void failDelete() {
+    given(jwtProvider.getUserIdFromAccessToken(RAW_TOKEN)).willReturn(USER_ID);
+    given(userRepository.findById(USER_ID)).willThrow(new RuntimeException("DB 연결 실패"));
+
+    assertThatThrownBy(() -> userService.deleteUser(RAW_TOKEN))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("DB 연결 실패");
+  }
+}


### PR DESCRIPTION
### 변경사항

- UserControllerTest
  - successGet() - 사용자 정보 조회 성공
    - GET /v1/users/me 요청 시 올바른 JWT 토큰을 Authorization 헤더에 포함하여 요청하도록 테스트하였습니다.
    - UserService의 getCurrentUser() 메서드가 정상적인 UserResponse를 반환하도록 Mock 설정하였습니다.
    - 응답 상태 코드가 200 OK인지 확인하였습니다.
    - jsonPath를 사용하여 반환된 JSON 응답의 id, email, name, profileImage 값이 예상값과 일치하는지 검증하였습니다.

  - failGet() - 사용자 정보 조회 실패
    - Authorization 헤더에 잘못된 형식의 토큰을 포함하여 요청하도록 테스트하였습니다.
    - 응답 상태 코드가 401 Unauthorized인지 확인하였습니다.
    - 인증 실패 상황에서 예외 처리가 정상적으로 동작하는지 검증하였습니다.

  - successUpdate() - 사용자 정보 수정 성공
    - PATCH /v1/users/me 요청 시 정상적인 JWT 토큰과 수정 요청 데이터를 포함하여 요청하도록 테스트하였습니다.
    - UserUpdateRequest 객체를 생성하여 수정할 name과 profileImage 값을 설정하였습니다.
    - UserService의 updateUser() 메서드가 수정된 UserResponse를 반환하도록 Mock 설정하였습니다.
    - 응답 상태 코드가 200 OK인지 확인하였습니다.
    - jsonPath를 사용하여 수정된 name 및 profileImage 값이 응답 데이터와 일치하는지 검증하였습니다.

  - failUpdate() - 사용자 정보 수정 실패
    - Authorization 헤더 없이 사용자 정보 수정 요청을 보내도록 테스트하였습니다.
    - 응답 상태 코드가 401 Unauthorized인지 확인하였습니다.
    - 인증 토큰이 없는 경우 접근이 차단되는지 검증하였습니다.

  - successDelete() - 회원 탈퇴 성공
    - DELETE /v1/users/me 요청 시 정상적인 JWT 토큰을 포함하여 요청하도록 테스트하였습니다.
    - UserService의 deleteUser() 메서드가 정상적으로 실행되도록 doNothing()으로 Mock 설정하였습니다.
    - 응답 상태 코드가 204 No Content인지 확인하였습니다.
    - 회원 탈퇴 요청이 정상적으로 처리되는지 검증하였습니다.

  - failDelete() - 회원 탈퇴 실패
    - Authorization 헤더 없이 회원 탈퇴 요청을 보내도록 테스트하였습니다.
    - 응답 상태 코드가 401 Unauthorized인지 확인하였습니다.
    - 인증 정보 없이 요청 시 접근이 차단되는지 검증하였습니다.

---

- UserService
  - getCurrentUser() - 현재 사용자 조회 기능
    - JwtProvider를 사용하여 Access Token에서 사용자 ID를 추출하도록 구현하였습니다.
    - UserRepository의 findById() 메서드를 통해 사용자를 조회하도록 구현하였습니다.
    - 사용자가 존재하지 않을 경우 CustomException(ErrorCode.NOT_FOUND_USER)를 발생시키도록 구현하였습니다.
    - JWT 토큰이 유효하지 않은 경우 CustomException(ErrorCode.INVALID_TOKEN)을 발생시키도록 예외 처리하였습니다.

  - updateUser() - 사용자 정보 수정 기능
    - Access Token으로 사용자 정보를 조회한 뒤 name 및 profileImage 값을 수정하도록 구현하였습니다.
    - name 값이 null이 아니고 공백이 아닐 경우에만 수정되도록 구현하였습니다.
    - profileImage는 null 여부만 검사하여 수정 또는 삭제가 가능하도록 구현하였습니다.
    - 수정된 사용자 정보를 saveAndFlush()를 통해 DB에 반영하도록 구현하였습니다.
    - 수정 완료 후 UserResponse 형태로 반환하도록 구현하였습니다.

  - deleteUser() - 회원 탈퇴 기능
    - Access Token을 통해 사용자 정보를 조회하도록 구현하였습니다.
    - deleteAllUserRelatedData() 메서드를 호출하여 사용자와 관련된 모든 데이터를 삭제하도록 구현하였습니다.
    - WorkspaceUser, WorkspaceInvite, WorkspaceInvitation, VoiceSessionUser, Canvas, Idea 등 연관 데이터를 삭제하도록 구현하였습니다.
    - 사용자가 Owner인 Workspace 내부 데이터 및 멤버십을 모두 삭제하도록 구현하였습니다.
    - Refresh Token을 null 처리한 뒤 User 엔티티를 삭제하도록 구현하였습니다.
    - 회원 탈퇴 완료 로그를 출력하도록 구현하였습니다.
    - 예외 발생 시 로그를 기록하고 예외를 다시 throw하도록 구현하였습니다.

  - deleteAllUserRelatedData() - 사용자 연관 데이터 삭제 기능
    - 사용자가 초대받았거나 생성한 초대 데이터를 모두 삭제하도록 구현하였습니다.
    - 사용자가 Owner인 Workspace를 조회하여 내부 Canvas 및 Idea 데이터를 삭제하도록 구현하였습니다.
    - Workspace 내부 모든 WorkspaceUser 데이터를 삭제하도록 구현하였습니다.
    - 삭제 완료 후 Workspace 엔티티를 삭제하도록 구현하였습니다.
    - 일반 멤버로 참여한 Workspace에 대해서는 Canvas의 WorkspaceUser 참조를 null 처리하도록 구현하였습니다.
    - VoiceSessionUser 데이터를 삭제하여 연관 관계를 정리하도록 구현하였습니다.

---

### 테스트

- [x] 테스트 코드
- [ ] API 테스트